### PR TITLE
Fix repository regex for ssh urls

### DIFF
--- a/travis-status.ts
+++ b/travis-status.ts
@@ -172,7 +172,7 @@ export default class TravisStatusIndicator {
 			
 			if (origin && origin.url) {
 				// Parse URL, get GitHub username
-				let repo = origin.url.replace(/^.*\/\/[^\/]+\//, '');
+				let repo = origin.url.replace(/^(.*\/\/)?[^\/:]+[\/:]/, '');
 				let combo = repo.replace(/(\.git)/, '');
 				let split = combo.split('/');
 				


### PR DESCRIPTION
This change makes it possible to parse git urls like `git@github.com:tmpvar/jsdom`, in addition to `https://github.com:tmpvar/jsdom` and `ssh://git@github.com/tmpvar/jsdom`.
