### PR TITLE
Specific commit build status

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out",
+			"outDir": "${workspaceRoot}/out",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out",
+			"outDir": "${workspaceRoot}/out",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "vscode": "latest"
   },
   "dependencies": {
+    "git-rev-2": "latest",
     "global-tunnel": "^1.2.0",
     "ini": "^1.3.4",
     "open": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -66,11 +66,12 @@
   },
   "scripts": {
     "vscode:prepublish": "tsc && node ./node_modules/vscode/bin/compile",
-    "compile": "tsc && node ./node_modules/vscode/bin/compile -watch -p ./"
+    "compile": "tsc && node ./node_modules/vscode/bin/compile -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
     "typescript": "^1.6.2",
-    "vscode": "next"
+    "vscode": "latest"
   },
   "dependencies": {
     "global-tunnel": "^1.2.0",


### PR DESCRIPTION
Resolves  #3 

I have added checking Travis for specific commit build.
### How does it work:
1. Get current active branch using git-rev-2(it basically just calls git rev-parse with appropriate options)
2. Get current active commit sha using git-rev-2
3. Call Travis API, the /branches/{branchName} variant.
4. Check if the current active commit sha and the build commit sha match.
5. If yes then show the build status with first seven sha chars in status bar. If not the fallback to master build status with "master" annotation in status bar.
### How does it look:
-  build present
  ![branch build](https://cloud.githubusercontent.com/assets/8547855/14658171/3e2786f2-0692-11e6-86af-e53574014627.png)
- fallback
  ![fallback](https://cloud.githubusercontent.com/assets/8547855/14658160/340b6c92-0692-11e6-91d0-1de9adde8ea6.png)

IMHO the commit sha is not very informative and it would be better to use words like "commit" and "master", the previous for current commit build and the second for fallback master build state.
### Known issues:
1. This solution does only check the last build from current branch. It is possible to search through all builds, but not for specific branch.
2. I believe that a potential use would expect that the extension will update the information on branch change/checkout. I do not know how to register the branch change and react to it.

@felixrieseberg what do you think?
