### PR TITLE
Add status polling with configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,24 @@ However, you can easily override that setting. Simply open or create `./.vscode/
 }
 ```
 
+By default, this extension will request a status update from Travis every 60 seconds. You can easily override this by changing the your `./.vscode/settings.json` file.
+
+To disable polling entirely, you can use:
+
+```json
+{
+    "travis.statusPolling": false
+```
+
+or to change the polling interval, you can use:
+
+```json
+{
+    "travis.statusPollingInterval": 30
+}
+```
+
+Which will set the polling interval to every 30 seconds. It is recommended that you don't attempt to poll for status changes too often.
+
 ## License
 MIT, please see LICENSE for details. Copyright (c) 2015 Felix Rieseberg and Microsoft Corporation.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,16 @@
           "type": "string",
           "default": "",
           "description": "Travis pro github password for authentication"
+        },
+        "travis.statusPolling": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether build status should be polled"
+        },
+        "travis.statusPollingInterval": {
+          "type": "number",
+          "default": 60,
+          "description": "Number of seconds between status polling requests"
         }
       }
     }

--- a/travis-status.ts
+++ b/travis-status.ts
@@ -1,4 +1,4 @@
-import {window, commands, StatusBarAlignment, StatusBarItem, workspace, extensions} from 'vscode';
+import { window, commands, StatusBarAlignment, StatusBarItem, workspace, extensions } from 'vscode';
 import path = require('path');
 import fs = require('fs');
 
@@ -8,10 +8,10 @@ var Git = require('git-rev-2');
 export default class TravisStatusIndicator {
 	private _travis;
 	private _statusBarItem: StatusBarItem;
-	private _useProxy : boolean = false;
-	private _proxyData = { host: null, port: null};
+	private _useProxy: boolean = false;
+	private _proxyData = { host: null, port: null };
 
-	public updateStatus() : void {
+	public updateStatus(): void {
 		if (!this._statusBarItem) {
 			this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
 			this._statusBarItem.command = 'extension.updateTravis';
@@ -35,7 +35,7 @@ export default class TravisStatusIndicator {
 				//Get head commit hash
 				Git.long(workspace.rootPath, (err2, currentCommitSha: string) => {
 					// Let's attempt getting a build status from Travis
-					this.getTravis().repos(username, repoName).branches(currentActiveBranch).get( (branchError, branchResponse) => {
+					this.getTravis().repos(username, repoName).branches(currentActiveBranch).get((branchError, branchResponse) => {
 						if (!branchError && branchResponse.commit.sha === currentCommitSha) {
 							let started: Date = new Date(branchResponse.branch.started_at);
 							let state: string = branchResponse.branch.state;
@@ -61,14 +61,21 @@ export default class TravisStatusIndicator {
 				});
 			});
 		}
+
+		// Should the status be polled?
+		let pollStatusSettings = this.getPollStatusFromSettings();
+		if (pollStatusSettings.pollStatus === true) {
+			// Run the update function again in the specified number of seconds
+			setTimeout(this.updateStatus.bind(this), pollStatusSettings.pollStatusInterval * 1000);
+		}
 	}
 
-	private show(buildDuration: number, state: string, buildNumber: number, started: Date, identifier?:string ) {
+	private show(buildDuration: number, state: string, buildNumber: number, started: Date, identifier?: string) {
 		let duration = Math.round(buildDuration / 60).toString();
 		duration += (duration === '1') ? ' minute' : ' minutes';
-		let timeInfo:string = `Started: ${started.toLocaleDateString()}\nDuration: ${duration}`
+		let timeInfo: string = `Started: ${started.toLocaleDateString()}\nDuration: ${duration}`
 
-		switch(state) {
+		switch (state) {
 			case 'passed':
 				return this.displaySuccess(`Build ${buildNumber} has passed.\n${timeInfo}`, identifier);
 			case 'started':
@@ -84,7 +91,7 @@ export default class TravisStatusIndicator {
 	}
 
 	// Opens the current project on Travis
-	public openInTravis() : void {
+	public openInTravis(): void {
 		if (!workspace || !workspace.rootPath || !this.isTravisProject()) return;
 
 		let open = require('open');
@@ -102,22 +109,20 @@ export default class TravisStatusIndicator {
 
 	// Check if a .travis.yml file is present, which indicates whether or not
 	// this is a Travis project
-	public isTravisProject() : Boolean {
+	public isTravisProject(): Boolean {
 		if (!workspace || !workspace.rootPath) return false;
 		let conf = path.join(workspace.rootPath, '.travis.yml');
 
-		try
-		{
+		try {
 			return fs.statSync(conf).isFile();
 		}
-		catch (err)
-		{
+		catch (err) {
 			return false;
 		}
 	}
 
 	// Checks whether or not the current folder has a GitHub remote
-	public getUserRepo() : Array<String> {
+	public getUserRepo(): Array<String> {
 		if (!workspace || !workspace.rootPath) return null;
 
 		let fSettings = this.getUserRepoFromSettings();
@@ -131,38 +136,38 @@ export default class TravisStatusIndicator {
 	}
 
 	// Setup status bar item to display that this plugin is in trouble
-	private displayError(err : string, identifier?: string) : void {
+	private displayError(err: string, identifier?: string): void {
 		this.setupStatusBarItem(err, 'stop', identifier);
 	}
 
 	// Setup status bar item to display that the build has passed;
-	private displaySuccess(text : string, identifier?: string) : void {
+	private displaySuccess(text: string, identifier?: string): void {
 		this.setupStatusBarItem(text, 'check', identifier);
 	}
 
 	// Setup status bar item to display that the build has failed;
-	private displayFailure(text : string, identifier?: string) : void {
+	private displayFailure(text: string, identifier?: string): void {
 		this.setupStatusBarItem(text, 'x', identifier);
 	}
 
 	// Setup status bar item to display that the build is running;
-	private displayRunning(text : string, identifier?: string) : void {
+	private displayRunning(text: string, identifier?: string): void {
 		this.setupStatusBarItem(text, 'clock', identifier);
 	}
 
 	// Setup StatusBarItem with an icon and a tooltip
-	private setupStatusBarItem(tooltip : string, icon : string, identifier?: string) : void {
+	private setupStatusBarItem(tooltip: string, icon: string, identifier?: string): void {
 		if (!this._statusBarItem) {
 			this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
 		}
 
-		this._statusBarItem.text = identifier? `Travis CI ${identifier} $(${icon})`:`Travis CI $(${icon})`;
+		this._statusBarItem.text = identifier ? `Travis CI ${identifier} $(${icon})` : `Travis CI $(${icon})`;
 		this._statusBarItem.tooltip = tooltip;
 		this._statusBarItem.show();
 	}
 
 	// Get the username/repository combo from .vscode/settings.json
-	private getUserRepoFromSettings() : Array<String> {
+	private getUserRepoFromSettings(): Array<String> {
 		if (!workspace || !workspace.rootPath) return null;
 
 		let settingsFile = path.join(workspace.rootPath, '.vscode', 'settings.json');
@@ -184,12 +189,11 @@ export default class TravisStatusIndicator {
 	}
 
 	// Get the username/repository combo from .travis.yml
-	private getUserRepoFromTravis() : Array<String> {
+	private getUserRepoFromTravis(): Array<String> {
 		let ini = require('ini');
 		let configFile = path.join(workspace.rootPath, '.git', 'config');
 
-		try
-		{
+		try {
 			let config = ini.parse(fs.readFileSync(configFile, 'utf-8'));
 			let origin = config['remote "origin"']
 
@@ -201,15 +205,35 @@ export default class TravisStatusIndicator {
 				if (repo.substr(repo.length - 4) === '.git') {
 					combo = repo.substr(0, repo.length - 4);
 				}
-	
+
 				let split = combo.split('/');
-				
+
 				return (split && split.length > 1) ? split : ['', ''];
 			}
 		}
-		catch (err)
-		{
+		catch (err) {
 			return ['', ''];
+		}
+	}
+
+	// Get the pollStatus/pollStatusInterval from .vscode/settings.json
+	private getPollStatusFromSettings(): { pollStatus: boolean, pollStatusInterval: number } {
+		if (!workspace || !workspace.rootPath) return null;
+
+		let settingsFile = path.join(workspace.rootPath, '.vscode', 'settings.json');
+
+		try {
+			let settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+
+			if (settings) {
+				let pollStatus = settings['travis.statusPolling'];
+				let pollStatusInterval = settings['travis.statusPollingInterval'];
+
+				return { pollStatus, pollStatusInterval };
+			}
+		}
+		catch (err) {
+			return { pollStatus: false, pollStatusInterval: null };
 		}
 	}
 
@@ -240,6 +264,6 @@ export default class TravisStatusIndicator {
 	}
 
 	dispose() {
-        this._statusBarItem.dispose();
-    }
+		this._statusBarItem.dispose();
+	}
 }


### PR DESCRIPTION
Adds status polling (default every 60 seconds) with configuration options to change both the polling time and disable polling entirely. These options are read from `./.vscode/settings.json` like the other settings. Could possibly update it later to read from the global configuration, but tbh I don't know enough about writing extensions to do this right now. See #18 