### PR TITLE
Use travis-ci.com for all repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,6 @@
           "default": "",
           "description": "Travis repository name for the project"
         },
-        "travis.pro": {
-          "type": "boolean",
-          "default": false,
-          "description": "Travis use pro or community"
-        },
         "travis.github_oauth_token": {
           "type": "string",
           "default": "",

--- a/travis-status.ts
+++ b/travis-status.ts
@@ -105,7 +105,7 @@ export default class TravisStatusIndicator {
 
 		let open = require('open');
 		let repo = this.getUserRepo();
-		let base = "https://travis-ci"
+		let base = "https://travis-ci.com/"
 		if (workspace.getConfiguration('travis')['pro']) {
 			base += '.com/'
 		} else {

--- a/travis-status.ts
+++ b/travis-status.ts
@@ -105,12 +105,7 @@ export default class TravisStatusIndicator {
 
 		let open = require('open');
 		let repo = this.getUserRepo();
-		let base = "https://travis-ci.com/"
-		if (workspace.getConfiguration('travis')['pro']) {
-			base += '.com/'
-		} else {
-			base += '.org/'
-		}
+		let base = "https://travis-ci.com/";
 		if (repo && repo.length === 2) {
 			return open(`${base}${repo[0]}/${repo[1]}`);
 		}


### PR DESCRIPTION
Previously, public repos were hosted at travis-ci.org. Now, all repos can be found at travis-ci.com.